### PR TITLE
Fixed incorrect CHIRPS link generation and other bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ run-drought-model
 You can find the versions in the [tags](https://github.com/rodekruis/ibf-drought-model/tags) of the commits. See below table to find which version of the pipeline corresponds to which version of IBF-Portal.
 | Drought Pipeline version  | IBF-Portal version | Changes |
 | --- | --- | --- |
-| v0.1.3 | 0.52.0 | Add function to post non-trigger in off-season |
+| v0.1.3 | 0.152.0 | Add function to post non-trigger in off-season |
 | v0.1.2 | 0.129.0 | Corrected generation of link to raw chirps file <br> Fixed misdownloading a processed rainfall from datalake <br> Fixed raw chirps files listing for calculating zonal statistics <br> Minor fixes |
 | v0.1.1 | - | ENSO+rainfall model added <br> Minor fixes | 
 | v0.1.0 | - | Initial version, ENSO-only model |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ run-drought-model
 ```
 
 ## Versions
-You can find the versions in the [tags](https://github.com/p-phung/ibf-drought-model/tags) of the commits. See below table to find which version of the pipeline corresponds to which version of IBF-Portal.
+You can find the versions in the [tags](https://github.com/rodekruis/ibf-drought-model/tags) of the commits. See below table to find which version of the pipeline corresponds to which version of IBF-Portal.
 | Drought Pipeline version  | IBF-Portal version | Changes |
 | --- | --- | --- |
 | v0.1.2 | 0.129.0 | Corrected generation of link to raw chirps file <br> Fixed misdownloading a processed rainfall from datalake <br> Fixed raw chirps files listing for calculating zonal statistics <br> Minor fixes |

--- a/README.md
+++ b/README.md
@@ -51,3 +51,11 @@ Run the pipeline with the command:
 ```
 run-drought-model
 ```
+
+## Versions
+You can find the versions in the [tags](https://github.com/p-phung/ibf-drought-model/tags) of the commits. See below table to find which version of the pipeline corresponds to which version of IBF-Portal.
+| Drought Pipeline version  | IBF-Portal version | Changes |
+| --- | --- | --- |
+| v0.1.2 | 0.129.0 | Corrected generation of link to raw chirps file <br> Fixed misdownloading a processed rainfall from datalake <br> Fixed raw chirps files listing for calculating zonal statistics <br> Minor fixes |
+| v0.1.1 | - | ENSO+rainfall model added <br> Minor fixes | 
+| v0.1.0 | - | Initial version, ENSO-only model |

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ run-drought-model
 You can find the versions in the [tags](https://github.com/rodekruis/ibf-drought-model/tags) of the commits. See below table to find which version of the pipeline corresponds to which version of IBF-Portal.
 | Drought Pipeline version  | IBF-Portal version | Changes |
 | --- | --- | --- |
+| v0.1.3 | 0.52.0 | Add function to post non-trigger in off-season |
 | v0.1.2 | 0.129.0 | Corrected generation of link to raw chirps file <br> Fixed misdownloading a processed rainfall from datalake <br> Fixed raw chirps files listing for calculating zonal statistics <br> Minor fixes |
 | v0.1.1 | - | ENSO+rainfall model added <br> Minor fixes | 
 | v0.1.0 | - | Initial version, ENSO-only model |

--- a/drought_model/src/drought_model/pipeline.py
+++ b/drought_model/src/drought_model/pipeline.py
@@ -25,10 +25,13 @@ def main():
         logging.error(f'Error in basic_data(): {e}')
 
     if month in months_inactive:
+        try:
+            post_none_output()
+        except Exception as e:
+            logging.error(f'Error in post_output(): {e}')
         continue_running = False
-        pass
         logging.info('Python timer trigger function ran at %s. \
-                        No output generated because of off-season', utc_timestamp)
+                        Non-trigger generated because of off-season', utc_timestamp)
 
     elif month in months_for_model1:
         try:

--- a/drought_model/src/drought_model/settings.py
+++ b/drought_model/src/drought_model/settings.py
@@ -2,25 +2,25 @@ import datetime
 
 
 # settings for posting output
-api_test = True # True/ False; True: to send output to the test server
-notify_email = False # True/ False; False: to disable sending email notification
+api_test = False # True/ False; True: to send output to the test server
+notify_email = True # True/ False; False: to disable sending email notification
 if api_test:
   api_info = 'ibf-credentials'
 else:
   api_info = 'ibf-credentials-zwe'
 
-# today
-today = datetime.date.today()
 
 # set dummy-mode. When the dummy-mode is on ("dummy = TRUE"), ENSO of August 2020 is extracted.
 dummy_time = False # True/ False
 dummy_data = False # True/ False
 
-# define month of execution
+# define month of execution (today)
 if dummy_time:
-  year = 2021
-  month = 9 
+  year = 2022
+  month = 1 
+  today = datetime.datetime(year, month, 20)
 else:
+  today = datetime.date.today()
   year = datetime.datetime.now().year
   month = datetime.datetime.now().month
 

--- a/drought_model/src/drought_model/utils.py
+++ b/drought_model/src/drought_model/utils.py
@@ -335,7 +335,7 @@ def get_new_chirps():
     
     if month == 1:
         year_data = year - 1 
-        month_data = month - 1
+        month_data = 12
     else:
         year_data = year
         month_data = month - 1
@@ -367,7 +367,7 @@ def get_new_chirps():
     # calculate monthly cumulative
     logging.info('get_new_chirps: calculating monthly cumulative rainfall')
 
-    filename_list = glob.glob(rawchirps_path + '*.tif')
+    filename_list = glob.glob(rawchirps_path + '/*.tif')
     i = 0
     for filename in filename_list:
         # raster_path = os.path.abspath(os.path.join(rawchirps_path, filename))
@@ -445,7 +445,7 @@ def arrange_data():
             df_data = df_data.merge(df_chirps, on='ADM2_PCODE')
     
     elif month == 1:
-        for month_data in [10, 11]:
+        for month_data in [10, 11, 12]:
             year_data = today.year - 1
             chirps_filename = 'chirps_' + '{0}-{1:02}'.format(year_data, month_data) + '.csv'
             blob_client = blob_service_client.get_blob_client(container='ibf',
@@ -467,6 +467,16 @@ def arrange_data():
                 download_file.write(blob_client.download_blob().readall())
             df_chirps = pd.read_csv(chirps_file_path)#.drop(columns='Unnamed: 0')#, sep=' ')
             df_data = df_data.merge(df_chirps, on='ADM2_PCODE')
+        month_data = 1
+        this_year = today.year
+        chirps_filename = 'chirps_' + '{0}-{1:02}'.format(this_year, month_data) + '.csv'
+        blob_client = blob_service_client.get_blob_client(container='ibf',
+                                                        blob='drought/Silver/zwe/chirps/'+ chirps_filename)
+        chirps_file_path = os.path.join(data_in_path, chirps_filename)
+        with open(chirps_file_path, "wb") as download_file:
+            download_file.write(blob_client.download_blob().readall())
+        df_chirps = pd.read_csv(chirps_file_path)#.drop(columns='Unnamed: 0')#, sep=' ')
+        df_data = df_data.merge(df_chirps, on='ADM2_PCODE')
 
     elif month == 3:
         for month_data in [10, 11, 12]:
@@ -479,16 +489,16 @@ def arrange_data():
                 download_file.write(blob_client.download_blob().readall())
             df_chirps = pd.read_csv(chirps_file_path)#.drop(columns='Unnamed: 0')#, sep=' ')
             df_data = df_data.merge(df_chirps, on='ADM2_PCODE')
-        month_data = 1
-        this_year = today.year
-        chirps_filename = 'chirps_' + '{0}-{1:02}'.format(this_year, month_data) + '.csv'
-        blob_client = blob_service_client.get_blob_client(container='ibf',
-                                                        blob='drought/Silver/zwe/chirps/'+ chirps_filename)
-        chirps_file_path = os.path.join(data_in_path, chirps_filename)
-        with open(chirps_file_path, "wb") as download_file:
-            download_file.write(blob_client.download_blob().readall())
-        df_chirps = pd.read_csv(chirps_file_path)#.drop(columns='Unnamed: 0')#, sep=' ')
-        df_data = df_data.merge(df_chirps, on='ADM2_PCODE')
+        for month_data in [1, 2]:
+            this_year = today.year
+            chirps_filename = 'chirps_' + '{0}-{1:02}'.format(this_year, month_data) + '.csv'
+            blob_client = blob_service_client.get_blob_client(container='ibf',
+                                                            blob='drought/Silver/zwe/chirps/'+ chirps_filename)
+            chirps_file_path = os.path.join(data_in_path, chirps_filename)
+            with open(chirps_file_path, "wb") as download_file:
+                download_file.write(blob_client.download_blob().readall())
+            df_chirps = pd.read_csv(chirps_file_path)#.drop(columns='Unnamed: 0')#, sep=' ')
+            df_data = df_data.merge(df_chirps, on='ADM2_PCODE')
     
     elif month == 4:
         for month_data in [10, 11, 12]:
@@ -501,7 +511,7 @@ def arrange_data():
                 download_file.write(blob_client.download_blob().readall())
             df_chirps = pd.read_csv(chirps_file_path)#.drop(columns='Unnamed: 0')#, sep=' ')
             df_data = df_data.merge(df_chirps, on='ADM2_PCODE')
-        for month_data in [1, 2]:
+        for month_data in [1, 2, 3]:
             this_year = today.year
             chirps_filename = 'chirps_' + '{0}-{1:02}'.format(this_year, month_data) + '.csv'
             blob_client = blob_service_client.get_blob_client(container='ibf',


### PR DESCRIPTION
Fixed:
- The month of January was read as 0 instead of 1. This generated an incorrect link to raw chirps files
- Processed rainfall data of one month was not downloaded from datalake
- Listing raw chirps files failed, leading to rainfall = 0 in calculating zonal statistics
- Other minor fixes